### PR TITLE
Checks on the data sets array dimensions

### DIFF
--- a/dso/dso/task/regression/regression.py
+++ b/dso/dso/task/regression/regression.py
@@ -124,6 +124,13 @@ class RegressionTask(HierarchicalTask):
             self.y_test = self.y_train
             self.y_test_noiseless = self.y_test
 
+        # Check that y training and testing data arrays are one dimensional numpy arrays
+        # Problems when they are not and almost exclusively seen with sklearn-like (X,y) data
+        if self.y_train.ndim!=1:
+            raise ValueError(f"The array containing the data set\'s function values at the training points, \'y_train', needs to be a one dimensional Numpy array and nothing else. The given array is a {self.y_train.ndim} dimensional.")
+        if self.y_test.ndim!=1:
+            raise ValueError(f"The array containing the data set\'s function values at the testing  points, \'y_test', needs to be a one dimensional Numpy array and nothing else. The given array is a {self.y_test.ndim} dimensional.")
+        
         # Save time by only computing data variances once
         self.var_y_test = np.var(self.y_test)
         self.var_y_test_noiseless = np.var(self.y_test_noiseless)

--- a/dso/dso/task/regression/sklearn.py
+++ b/dso/dso/task/regression/sklearn.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
+from numpy import ndarray
 
 from dso import DeepSymbolicOptimizer
 
@@ -21,6 +22,14 @@ class DeepSymbolicRegressor(DeepSymbolicOptimizer,
 
     def fit(self, X, y):
 
+        # Do some various input argument checking.
+        if not(isinstance(X, ndarray) and isinstance(y, ndarray)):
+            raise TypeError(f"Both functional arguments (X, y) are to be Numpy ndarray class objects. The given function objects where "+type(X).__name__ + " and "+type(y).__name__ +" class objects respectively.")
+        if X.ndim!=2:
+            raise ValueError(f"The first function argument, \'X', needs to be a two dimensional Numpy array and nothing else. The given argument is a {X.ndim} dimensional array.")
+        if y.ndim!=1:
+            raise ValueError(f"The second function arguement, \'y', needs to be a one dimensional Numpy array and nothing else. The given array is a {y.ndim} dimensional array.")
+        
         # Update the Task
         config = deepcopy(self.config)
         config["task"]["dataset"] = (X, y)


### PR DESCRIPTION
Added a few lines of code to the Sklearn.py and regression.py files both found within the task subfolder. I had noticed some weird and unexpected behavior while using the sklearn interface for the dso library when the function argument y for the fit function was not a one dimensional numpy array (See the recently closed issue made by myself tilted Different Learning Equations with Different Numpy Array shape). So fix this issue, within the sklearn.py file I have added a few lines of code to check that the function arguments (X,y) to the fit are first numpy ndarray class objects then if X and y have exactly 2 and 1 array dimensional respectively. A type error is through when the arguments are not numpy arrays and a value error is raised when the number of array dimensions for X or y is incorrect. Additionally, within the regression.py file of the dso library I have added similar error checking within the initialization method of the RegressionTask class but only for the y_train and y_test arrays of the RegressionTask (that they are single dimensional arrays) only after the have been created through either of 4 possible supported use cases.